### PR TITLE
Fix code scanning alert no. 10: Uncontrolled command line

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,7 @@ var ms = require('ms');
 var streamBuffers = require('stream-buffers');
 var readline = require('readline');
 var moment = require('moment');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var validator = require('validator');
 
 // zip-slip
@@ -158,7 +158,7 @@ exports.create = function (req, res, next) {
     var url = item.match(imgRegex)[1];
     console.log('found img: ' + url);
 
-    exec('identify ' + url, function (err, stdout, stderr) {
+    execFile('identify', [url], function (err, stdout, stderr) {
       console.log(err);
       if (err !== null) {
         console.log('Error (' + err + '):' + stderr);


### PR DESCRIPTION
Fixes [https://github.com/magnologan/nodejs-goof/security/code-scanning/10](https://github.com/magnologan/nodejs-goof/security/code-scanning/10)

To fix the problem, we should avoid using `child_process.exec` and instead use `child_process.execFile` or `child_process.execFileSync`, which do not spawn a shell and accept command arguments as an array of strings. This approach is safer and prevents command injection vulnerabilities.

**Steps to fix:**
1. Replace `child_process.exec` with `child_process.execFile`.
2. Pass the command and its arguments as separate elements in an array.
3. Ensure that the `url` is properly validated or sanitized if necessary.

