### PR TITLE
Fix code scanning alert no. 7: Template Object Injection

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -103,8 +103,17 @@ exports.save_account_details = function(req, res, next) {
     profile.firstname = validator.rtrim(profile.firstname)
     profile.lastname = validator.rtrim(profile.lastname)
 
+    // construct a new object with only the necessary properties
+    const safeProfile = {
+      email: profile.email,
+      phone: profile.phone,
+      firstname: profile.firstname,
+      lastname: profile.lastname,
+      country: profile.country
+    }
+
     // render the view
-    return res.render('account.hbs', profile)
+    return res.render('account.hbs', safeProfile)
   } else {
     // if input validation fails, we just render the view as is
     console.log('error in form details')


### PR DESCRIPTION
Fixes [https://github.com/magnologan/nodejs-goof/security/code-scanning/7](https://github.com/magnologan/nodejs-goof/security/code-scanning/7)

To fix the problem, we need to ensure that only the necessary and validated properties of the `profile` object are passed to the template engine. This involves explicitly constructing a new object with only the required properties before passing it to `res.render`.

- Identify the necessary properties that the template requires.
- Construct a new object with only these properties from the validated `profile` object.
- Pass this new object to `res.render` instead of the entire `profile` object.
